### PR TITLE
Implement SandboxVars to adjust reading and transcription speed

### DIFF
--- a/Contents/mods/Skill Recovery Journal/media/lua/client/zzz/Skill Recovery Journal Main.lua
+++ b/Contents/mods/Skill Recovery Journal/media/lua/client/zzz/Skill Recovery Journal Main.lua
@@ -159,7 +159,7 @@ function ISReadABook:update()
 				local currentXP = player:getXp():getXP(Perks[skill])
 
 				if currentXP < xp then
-					local readTimeMulti = SandboxVars.SkillRecoveryJournal.ReadTimeMulti or 1
+					local readTimeMulti = SandboxVars.Character.ReadTimeMulti or 1
 					local perkLevel = player:getPerkLevel(Perks[skill])+1
 					local perPerkXpRate = (math.floor(((xpRate^perkLevel)*(10*perkLevel))*1000)/1000) / readTimeMulti
 					if perkLevel == 11 then
@@ -244,7 +244,7 @@ function ISCraftAction:update()
 		local gainedXP = JMD["gainedXP"]
 		--local debug_text = "ISCraftAction:update - "
 
-		local transcribeSpeed = SandboxVars.SkillRecoveryJournal.TranscribeSpeed or 0
+		local transcribeSpeed = SandboxVars.Character.TranscribeSpeed or 0
 		if writing and gainedXP then
 			local transcribing = false
 			for skill,xp in pairs(recoverableXP) do
@@ -374,7 +374,7 @@ function ISCraftAction:new(character, item, time, recipe, container, containers)
 		end
 		o.maxTime = o.maxTime+(xpDiff)+(math.floor(math.sqrt(recipeDiff)+0.5)*50)
 		
-		local transcribeSpeed = SandboxVars.SkillRecoveryJournal.TranscribeSpeed or 0
+		local transcribeSpeed = SandboxVars.Character.TranscribeSpeed or 0
 		if transcribeSpeed > 0 then
 			o.loopedAction = false
 			o.useProgressBar = false
@@ -524,7 +524,7 @@ function SRJ.calculateGainedSkills(player)
 					local perkLevel = perkInfo:getLevel()
 					local perkType = tostring(perk:getType())
 					local bonusLevelsFromTrait = bonusLevels[perkType] or 0
-					local recoverableXPFactor = (SandboxVars.SkillRecoveryJournal.RecoveryPercentage/100) or 1
+					local recoverableXPFactor = (SandboxVars.Character.RecoveryPercentage/100) or 1
 					local recoverableXP = perk:getTotalXpForLevel(perkLevel)
 
 					recoverableXP = (recoverableXP-perk:getTotalXpForLevel(bonusLevelsFromTrait))*recoverableXPFactor

--- a/Contents/mods/Skill Recovery Journal/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/Contents/mods/Skill Recovery Journal/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -2,4 +2,8 @@ Sandbox_EN = {
 	Sandbox_SkillRecoveryJournal = "Skill Recovery Journal",
 	Sandbox_SkillRecoveryJournalPercentage = "Skill Recovery Percentage",
 	Sandbox_SkillRecoveryJournalPercentage_tooltip = "The amount of experienced recovered from reading bound journals.",
+	Sandbox_SkillRecoveryJournalTranscribeSpeed = "Transcribe Speed",
+	Sandbox_SkillRecoveryJournalTranscribeSpeed_tooltip = "Amount of xp transcribed per time. 0 = Auto (Fast)"
+	Sandbox_SkillRecoveryJournalReadTimeMulti = "Skill Recovery Time Multiplier",
+	Sandbox_SkillRecoveryJournalReadTimeMulti_tooltip = "A multiplier on the time needed to read bound journals."
 	}

--- a/Contents/mods/Skill Recovery Journal/media/sandbox-options.txt
+++ b/Contents/mods/Skill Recovery Journal/media/sandbox-options.txt
@@ -5,3 +5,15 @@ option SkillRecoveryJournal.RecoveryPercentage
 	type = integer, min = 1, max = 100, default = 100,
 	page = Character, translation = SkillRecoveryJournalPercentage,
 }
+
+option SkillRecoveryJournal.TranscribeSpeed
+{
+	type = double, min = 0, max = 10000, default = 0,
+	page = Character, translation = SkillRecoveryJournalTranscribeSpeed,
+}
+
+option SkillRecoveryJournal.ReadTimeMulti
+{
+	type = integer, min = 1, max = 10000, default = 1,
+	page = Character, translation = SkillRecoveryJournalReadTimeMulti,
+}

--- a/Contents/mods/Skill Recovery Journal/media/sandbox-options.txt
+++ b/Contents/mods/Skill Recovery Journal/media/sandbox-options.txt
@@ -6,13 +6,13 @@ option Character.RecoveryPercentage
 	page = Character, translation = SkillRecoveryJournalPercentage,
 }
 
-option SkillRecoveryJournal.TranscribeSpeed
+option Character.TranscribeSpeed
 {
 	type = double, min = 0, max = 10000, default = 0,
 	page = Character, translation = SkillRecoveryJournalTranscribeSpeed,
 }
 
-option SkillRecoveryJournal.ReadTimeMulti
+option Character.ReadTimeMulti
 {
 	type = integer, min = 1, max = 10000, default = 1,
 	page = Character, translation = SkillRecoveryJournalReadTimeMulti,


### PR DESCRIPTION
- add ReadTimeMulti, acts as divider for xp gained per update while reading (default=1)
- add TranscribeSpeed, if set >0 will disable progressbar handling and define amount of xp transcribed per update while transcribing (default=0)

Additional Notes:
Will not change any behaviour on default settings.