### PR TITLE
normalize update (xp gain and transcribe) times via ingame-time

### DIFF
--- a/Contents/mods/Skill Recovery Journal/media/lua/client/Skill Recovery Journal Main.lua
+++ b/Contents/mods/Skill Recovery Journal/media/lua/client/Skill Recovery Journal Main.lua
@@ -1,4 +1,4 @@
-Events.OnGameBoot.Add(print("Skill Recovery Journal: ver:0.3.3-recoveryJournalXpLog-HOTFIX"))
+Events.OnGameBoot.Add(print("Skill Recovery Journal: ver:0.3.3-ingame-time-SNAPSHOT"))
 
 SRJ = {}
 

--- a/Contents/mods/Skill Recovery Journal/media/lua/client/Skill Recovery Journal Read.lua
+++ b/Contents/mods/Skill Recovery Journal/media/lua/client/Skill Recovery Journal Read.lua
@@ -8,118 +8,127 @@ function ISReadABook:update()
 	local journal = self.item
 
 	if journal:getType() == "SkillRecoveryJournal" then
-		---@type IsoGameCharacter | IsoPlayer | IsoMovingObject | IsoObject
-		local player = self.character
+		self.readTimer = self.readTimer + getGameTime():getMultiplier();
 
-		local journalModData = journal:getModData()
-		local JMD = journalModData["SRJ"]
-		local gainedXp = false
+		-- normalize update time via in game time. Adjust updateInterval as needed
+		local updateInterval = 10
+		if self.readTimer >= updateInterval then
+			self.readTimer = 0
+			
+			---@type IsoGameCharacter | IsoPlayer | IsoMovingObject | IsoObject
+			local player = self.character
 
-		local delayedStop = false
-		local sayText
-		local sayTextChoices = {"IGUI_PlayerText_DontUnderstand", "IGUI_PlayerText_TooComplicated", "IGUI_PlayerText_DontGet"}
+			local journalModData = journal:getModData()
+			local JMD = journalModData["SRJ"]
+			local gainedXp = false
 
-		local pSteamID = player:getSteamID()
+			local delayedStop = false
+			local sayText
+			local sayTextChoices = {"IGUI_PlayerText_DontUnderstand", "IGUI_PlayerText_TooComplicated", "IGUI_PlayerText_DontGet"}
 
-		if (not JMD) then
-			delayedStop = true
-			sayText = getText("IGUI_PlayerText_NothingWritten")
+			local pSteamID = player:getSteamID()
 
-		elseif self.character:HasTrait("Illiterate") then
-			delayedStop = true
-
-		elseif pSteamID ~= 0 then
-			JMD["ID"] = JMD["ID"] or {}
-			local journalID = JMD["ID"]
-			if journalID["steamID"] and (journalID["steamID"] ~= pSteamID) then
+			if (not JMD) then
 				delayedStop = true
-				sayText = getText("IGUI_PlayerText_DoesntFeelRightToRead")
-			end
-		end
+				sayText = getText("IGUI_PlayerText_NothingWritten")
 
-		if not delayedStop then
+			elseif self.character:HasTrait("Illiterate") then
+				delayedStop = true
 
-			local learnedRecipes = JMD["learnedRecipes"] or {}
-			for recipeID,_ in pairs(learnedRecipes) do
-				if not player:isRecipeKnown(recipeID) then
-					player:learnRecipe(recipeID)
-					gainedXp = true
+			elseif pSteamID ~= 0 then
+				JMD["ID"] = JMD["ID"] or {}
+				local journalID = JMD["ID"]
+				if journalID["steamID"] and (journalID["steamID"] ~= pSteamID) then
+					delayedStop = true
+					sayText = getText("IGUI_PlayerText_DoesntFeelRightToRead")
 				end
 			end
 
-			local gainedXP = JMD["gainedXP"]
-			local maxXP = 0
+			if not delayedStop then
 
-			for skill,xp in pairs(gainedXP) do
-				if skill and skill~="NONE" or skill~="MAX" then
-					if xp > maxXP then
-						maxXP = xp
-					end
-				else
-					gainedXP[skill] = nil
-				end
-			end
-
-			local XpMultiplier = SandboxVars.XpMultiplier or 1
-			local xpRate = (maxXP/self.maxTime)/XpMultiplier
-
-			local minutesPerPage = 1
-			if isClient() then
-				minutesPerPage = getServerOptions():getFloat("MinutesPerPage") or 1
-			end
-			xpRate = minutesPerPage / minutesPerPage
-
-			local pMD = player:getModData()
-			pMD.recoveryJournalXpLog = pMD.recoveryJournalXpLog or {}
-			local readXp = pMD.recoveryJournalXpLog
-
-			for skill,xp in pairs(gainedXP) do
-
-				local currentXP = readXp[skill]
-				if not currentXP then
-					readXp[skill] = 0
-					currentXP = readXp[skill]
-				end
-
-				if currentXP < xp then
-					local readTimeMulti = SandboxVars.Character.ReadTimeMulti or 1
-					local perkLevel = player:getPerkLevel(Perks[skill])+1
-					local perPerkXpRate = math.floor(((xpRate*math.sqrt(perkLevel))*1000)/1000) * readTimeMulti
-					if perkLevel == 11 then
-						perPerkXpRate=0
-					end
-					--print ("TESTING:  perPerkXpRate:"..perPerkXpRate.."  perkLevel:"..perkLevel.."  xpStored:"..xp.."  currentXP:"..currentXP)
-					if currentXP+perPerkXpRate > xp then
-						perPerkXpRate = (xp-(currentXP-0.01))
-						--print(" --xp overflowed, capped at:"..perPerkXpRate)
-					end
-
-					if perPerkXpRate>0 then
-						readXp[skill] = readXp[skill]+perPerkXpRate
-						player:getXp():AddXP(Perks[skill], perPerkXpRate, true, true, false, true)
+				local learnedRecipes = JMD["learnedRecipes"] or {}
+				for recipeID,_ in pairs(learnedRecipes) do
+					if not player:isRecipeKnown(recipeID) then
+						player:learnRecipe(recipeID)
 						gainedXp = true
-						self:resetJobDelta()
 					end
 				end
-			end
 
-			if JMD and (not gainedXp) then
-				delayedStop = true
-				sayTextChoices = {"IGUI_PlayerText_KnowSkill","IGUI_PlayerText_BookObsolete"}
-				sayText = getText(sayTextChoices[ZombRand(#sayTextChoices)+1])
-				--else
-				--	self:resetJobDelta()
-			end
-		end
+				local gainedXP = JMD["gainedXP"]
+				local maxXP = 0
 
-		if delayedStop then
-			if self.pageTimer >= self.maxTime then
-				self.pageTimer = 0
-				self.maxTime = 0
-				if sayText then
-					player:Say(sayText, 0.55, 0.55, 0.55, UIFont.Dialogue, 0, "default")
+				for skill,xp in pairs(gainedXP) do
+					if skill and skill~="NONE" or skill~="MAX" then
+						if xp > maxXP then
+							maxXP = xp
+						end
+					else
+						gainedXP[skill] = nil
+					end
 				end
-				self:forceStop()
+
+				local XpMultiplier = SandboxVars.XpMultiplier or 1
+				local xpRate = (maxXP/self.maxTime)/XpMultiplier
+
+				local minutesPerPage = 1
+				if isClient() then
+					minutesPerPage = getServerOptions():getFloat("MinutesPerPage") or 1
+				end
+				xpRate = minutesPerPage / minutesPerPage
+
+				local pMD = player:getModData()
+				pMD.recoveryJournalXpLog = pMD.recoveryJournalXpLog or {}
+				local readXp = pMD.recoveryJournalXpLog
+
+				for skill,xp in pairs(gainedXP) do
+
+					local currentXP = readXp[skill]
+					if not currentXP then
+						readXp[skill] = 0
+						currentXP = readXp[skill]
+					end
+
+					if currentXP < xp then
+						local readTimeMulti = SandboxVars.Character.ReadTimeMulti or 1
+						local perkLevel = player:getPerkLevel(Perks[skill])+1
+						local perPerkXpRate = math.floor(((xpRate*math.sqrt(perkLevel))*1000)/1000) * readTimeMulti
+						if perkLevel == 11 then
+							perPerkXpRate=0
+						end
+						--print ("TESTING:  perPerkXpRate:"..perPerkXpRate.."  perkLevel:"..perkLevel.."  xpStored:"..xp.."  currentXP:"..currentXP)
+						if currentXP+perPerkXpRate > xp then
+							perPerkXpRate = (xp-(currentXP-0.01))
+							--print(" --xp overflowed, capped at:"..perPerkXpRate)
+						end
+
+						if perPerkXpRate>0 then
+							readXp[skill] = readXp[skill]+perPerkXpRate
+							player:getXp():AddXP(Perks[skill], perPerkXpRate, true, true, false, true)
+							gainedXp = true
+							self:resetJobDelta()
+						end
+					end
+				end
+
+				if JMD and (not gainedXp) then
+					delayedStop = true
+					sayTextChoices = {"IGUI_PlayerText_KnowSkill","IGUI_PlayerText_BookObsolete"}
+					sayText = getText(sayTextChoices[ZombRand(#sayTextChoices)+1])
+					--else
+					--	self:resetJobDelta()
+				end
+			end
+
+			if delayedStop then
+				if self.pageTimer >= self.maxTime then
+					self.pageTimer = 0
+					self.maxTime = 0
+					self.readTimer = 0
+					if sayText then
+						player:Say(sayText, 0.55, 0.55, 0.55, UIFont.Dialogue, 0, "default")
+					end
+					self:forceStop()
+				end
 			end
 		end
 	end
@@ -134,6 +143,7 @@ function ISReadABook:new(player, item, time)
 		o.loopedAction = false
 		o.useProgressBar = false
 		o.maxTime = 100
+		o.readTimer = 0
 
 		local journalModData = item:getModData()
 		local JMD = journalModData["SRJ"]


### PR DESCRIPTION
Write works as intended, read can not be tested as it is not working on main.

Should solve #11  but will increase default reading and transcribe times.

Git diff looks much worse than it is, its actually just ~6 lines per file. Needed to put in a lot of tabs for the surrounding check though, seems git did not like that.