### PR TITLE
Fix recipe recovery in B42

### DIFF
--- a/Contents/mods/Skill Recovery Journal/42.0/media/lua/client/Skill Recovery Journal Reading.lua
+++ b/Contents/mods/Skill Recovery Journal/42.0/media/lua/client/Skill Recovery Journal Reading.lua
@@ -366,7 +366,7 @@ function ReadSkillRecoveryJournal:new(character, item)
 			local learnedRecipes = JMD["learnedRecipes"]
 			if learnedRecipes then
 				for recipeID,_ in pairs(learnedRecipes) do
-					if not character:isRecipeKnown(recipeID) then
+					if not character:isRecipeActuallyKnown(recipeID) then
 						table.insert(o.learnedRecipes, recipeID)
 					end
 				end


### PR DESCRIPTION
B42 differentiates between learned and known recipes. When a character dies, the recipe stays visible/known, and isRecipeKnown reports true.

isRecipeActuallyKnown checks if the current character has learned it.